### PR TITLE
fixing support for "key" properties

### DIFF
--- a/lib/patch/applyProperties.js
+++ b/lib/patch/applyProperties.js
@@ -19,6 +19,9 @@ function applyProperties(node, props, previous) {
 }
 
 function removeProperty(node, propName, previous) {
+  if (!previous) {
+    return
+  }
   var previousValue = previous[propName]
 
   if (propName === "attributes") {

--- a/test/test.js
+++ b/test/test.js
@@ -68,7 +68,8 @@ var structures = [
     'font-weight': 'normal',
     'font-size': '12px',
     'color': 'white'
-  }})
+  }}),
+  h('div', {key: 'something'})
 ];
 
 describe('test suite', function () {


### PR DESCRIPTION
Hey, Nolan. I've been messing around with the whole feather-app idea more and starting to build some "real" apps with it and hit this snag.

Noticed that vdom-seralized-patch errors when there are `key` properties because the `previous` argument is `undefined` within `removeProperty`.

In virtual-dom itself there's a simple check when removing properties, presumably for the same error: https://github.com/Matt-Esch/virtual-dom/blob/master/vdom/apply-properties.js#L30

This PR just takes the same approach.
