### PR TITLE
Added support for thunks

### DIFF
--- a/lib/patch/patchOp.js
+++ b/lib/patch/patchOp.js
@@ -4,7 +4,7 @@ var render = require('./createElement');
 
 module.exports = applyPatch
 
-function applyPatch(vpatch, domNode) {
+function applyPatch(vpatch, domNode, patchRecursive) {
   var type = vpatch[0]
   var patch = vpatch[1]
   var vNode = vpatch[2]
@@ -24,6 +24,9 @@ function applyPatch(vpatch, domNode) {
     case patchTypes.PROPS:
       applyProperties(domNode, patch, vNode.p) // 'p' === 'properties'
       return domNode
+    case patchTypes.THUNK:
+      return replaceRoot(domNode,
+          patchRecursive(domNode, patch))
     default:
       return domNode
   }
@@ -101,4 +104,12 @@ function reorderChildren(domNode, moves) {
     // this is the weirdest bug i've ever seen in webkit
     domNode.insertBefore(node, insert.to >= length++ ? null : childNodes[insert.to])
   }
+}
+
+function replaceRoot(oldRoot, newRoot) {
+    if (oldRoot && newRoot && oldRoot !== newRoot && oldRoot.parentNode) {
+        oldRoot.parentNode.replaceChild(newRoot, oldRoot)
+    }
+
+    return newRoot;
 }

--- a/lib/patch/patchRecursive.js
+++ b/lib/patch/patchRecursive.js
@@ -28,7 +28,7 @@ function applyPatch(rootNode, domNode, patchList) {
   var newNode
 
   for (var i = 0; i < patchList.length; i++) {
-    newNode = patchOp(patchList[i], domNode)
+    newNode = patchOp(patchList[i], domNode, patchRecursive)
 
     if (domNode === rootNode) {
       rootNode = newNode

--- a/lib/serialize/index.js
+++ b/lib/serialize/index.js
@@ -40,7 +40,7 @@ function serializeVirtualPatch(vPatch) {
   var type = vPatch.type;
   var res = [
     type,
-    toJson(vPatch.patch)
+    vPatch.patch && vPatch.patch.a ? toJson(serializeRootPatch(vPatch.patch)) : toJson(vPatch.patch)
   ];
 
   if (type === patchTypes.PROPS) {
@@ -50,7 +50,7 @@ function serializeVirtualPatch(vPatch) {
   return res;
 }
 
-module.exports = function (patch) {
+function serializeRootPatch(patch) {
   var outputRootNode = serializeCurrentNode(patch.a);
 
   var res = {
@@ -65,3 +65,4 @@ module.exports = function (patch) {
 
   return res;
 };
+module.exports = serializeRootPatch;

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,15 @@ if (!process.browser) {
   global.document = jsdom('<html><body></body></html>');
 }
 
+function Thunk(str){
+  this.str = str;
+}
+function renderThunk(){
+  return h("div", this.str);
+}
+Thunk.prototype.type = "Thunk";
+Thunk.prototype.render = renderThunk;
+
 var structures = [
   h("div", "hello"),
   h("div", [h("span", "goodbye")]),
@@ -78,7 +87,8 @@ var structures = [
   h('div', {key: 'something'}),
   h('div', {style: {background: 'blue', color: 'red'}}),
   h('div', {}),
-  h('input', {type: 'text', value: 'SoftSetHook'})
+  h('input', {type: 'text', value: 'SoftSetHook'}),
+  new Thunk("thunktest")
 ];
 
 describe('test suite', function () {


### PR DESCRIPTION
Hey,

Using VDom in a web worker is a big performance improvement, but when working with immutable data structures (like in PureScript) thunks can make a big difference to the amount of work the WW has to do. I couldn't figure out why thunks weren't supported, so I experimented a bit and figured out how to make it work, at least in my use case. Let me know if I'm missing anything!

Simon
